### PR TITLE
Scrub bf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     ]
   },
   "keywords": [
-    "botbuilder",
-    "Microsoft Bot Framework"
+    "conversation",
+    "conversational",
+    "dialog"
   ],
   "homepage": "https://github.com/wolf-packs/wolf-core",
   "repository": {
@@ -54,9 +55,6 @@
     "@types/jest": "^22.2.3",
     "@types/uuid": "^3.4.4",
     "body-parser": "^1.18.3",
-    "botbuilder": "^4.0.0-preview1.2",
-    "botbuilder-node": "^4.0.0-m1.10",
-    "botbuilder-services": "^4.0.0-m1.10",
     "botbuilder-wolf-rive": "^1.1.2",
     "bravey": "^0.1.5",
     "dotenv": "^6.0.0",
@@ -69,7 +67,6 @@
     "uuid": "^3.3.2"
   },
   "dependencies": {
-    "botbuilder-redux": "^2.1.0",
     "debug": "^3.1.0",
     "immutable": "^3.8.2",
     "lodash.difference": "^4.5.0",

--- a/src/helpers/find.ts
+++ b/src/helpers/find.ts
@@ -1,11 +1,11 @@
 import { Slot, Ability, SlotId } from '../types'
 
-export const findSlotByEntityName = 
-  (slotName: string, slots: Slot[]) => slots.find((slot) => slot.name === slotName)
-export const findAbilityByName = 
-  (abilityName: string, abilities: Ability[]) => abilities.find(ability => ability.name === abilityName)
+export const findSlotByEntityName =
+  <T>(slotName: string, slots: Slot<T>[]) => slots.find((slot) => slot.name === slotName)
+export const findAbilityByName =
+  <T>(abilityName: string, abilities: Ability<T>[]) => abilities.find(ability => ability.name === abilityName)
 export const findSlotInAbilitiesBySlotId =
-  (abilities: Ability[], slotId: SlotId): Slot | undefined => {
+  <T>(abilities: Ability<T>[], slotId: SlotId): Slot<T> | undefined => {
     const ability = abilities.find(ability => ability.name === slotId.abilityName)
     if (!ability) {
       return
@@ -13,11 +13,11 @@ export const findSlotInAbilitiesBySlotId =
     const slot = ability.slots.find(slot => slot.name === slotId.slotName)
     return slot
   }
-export const findIndexOfSlotIdsBySlotId = 
+export const findIndexOfSlotIdsBySlotId =
   (array: SlotId[], slotId: SlotId): number => array.findIndex((arrId) => {
     return arrId.abilityName === slotId.abilityName && arrId.slotName === slotId.slotName
   })
-export const findInSlotIdItemBySlotId = 
+export const findInSlotIdItemBySlotId =
   <T extends SlotId>(array: T[], slotId: SlotId): T => array.find(arrSlotId => {
     return arrSlotId.abilityName === slotId.abilityName && arrSlotId.slotName === slotId.slotName
   }) as T

--- a/src/selectors/fillSlotSelectors.ts
+++ b/src/selectors/fillSlotSelectors.ts
@@ -6,23 +6,23 @@ import { findIndexOfSlotIdsBySlotId } from '../helpers'
 
 export const getPromptedSlotId = (state: WolfState): SlotId => state.promptedSlotStack[0]
 
-export const getSlotBySlotId = (abilities: Ability[], slotInfo: SlotId): Slot | undefined => {
-  const ability = abilities.find((ability: Ability) => ability.name === slotInfo.abilityName)
-  if (! ability) {
+export const getSlotBySlotId = <T>(abilities: Ability<T>[], slotInfo: SlotId): Slot<T> | undefined => {
+  const ability = abilities.find((ability: Ability<T>) => ability.name === slotInfo.abilityName)
+  if (!ability) {
     return
   }
-  const foundSlot = ability.slots.find((slot: Slot) => slot.name === slotInfo.slotName)
+  const foundSlot = ability.slots.find((slot: Slot<T>) => slot.name === slotInfo.slotName)
   return foundSlot
 }
 
-export const isPromptStatus = (state: WolfState) => { 
+export const isPromptStatus = (state: WolfState) => {
   return state.promptedSlotStack[0] ? state.promptedSlotStack[0].prompted : false
 }
 
 export const isFocusedAbilitySet = (state: WolfState) => state.focusedAbility
 
 export const getSlotTurnCount = (state: WolfState, slotId: SlotId): number => {
-  const promptSlot = state.promptedSlotStack.find((promptSlot: PromptSlot) => 
+  const promptSlot = state.promptedSlotStack.find((promptSlot: PromptSlot) =>
     promptSlot.slotName === slotId.slotName && promptSlot.abilityName === slotId.abilityName
   )
   if (promptSlot) {
@@ -31,7 +31,7 @@ export const getSlotTurnCount = (state: WolfState, slotId: SlotId): number => {
   return 0
 }
 
-export const getTargetAbility = (abilities: Ability[], targetAbility: string): Ability | undefined => {
+export const getTargetAbility = <T>(abilities: Ability<T>[], targetAbility: string): Ability<T> | undefined => {
   return abilities.find((ability) => ability.name === targetAbility)
 }
 
@@ -39,7 +39,7 @@ export const getRequestingSlotIdFromCurrentSlotId = (state: WolfState, slotId: S
   const slotIndex = findIndexOfSlotIdsBySlotId(state.slotStatus, slotId)
   const slot: SlotStatus = state.slotStatus[slotIndex]
   if (!slot.requestingSlot) {
-    throw new Error (`You did not request any slot to use this slot to confirm`)
+    throw new Error(`You did not request any slot to use this slot to confirm`)
   }
   return {
     abilityName: slot.abilityName,

--- a/src/stages/evaluate.ts
+++ b/src/stages/evaluate.ts
@@ -315,7 +315,7 @@ function getMissingSlotsOnSlotStatus<T>(
   return abilitySlots
     .map((_: Slot<T>) => _.name)
     .filter((_: string) => namesOfSlotStatusOnAbility.indexOf(_) === -1)
-    .map((_: any) => ({
+    .map((_: string) => ({
       abilityName: focusedAbility,
       slotName: _
     }))

--- a/src/stages/evaluate.ts
+++ b/src/stages/evaluate.ts
@@ -22,7 +22,7 @@ const log = require('debug')('wolf:s3')
  * @param store redux
  * @param abilities user defined abilities and slots
  */
-export default function evaluate<T>(store: Store<WolfState>, abilities: Ability[], convoState: T): void {
+export default function evaluate<T>(store: Store<WolfState>, abilities: Ability<T>[], convoState: T): void {
   const { dispatch, getState } = store
 
   const state = getState()
@@ -211,7 +211,7 @@ export default function evaluate<T>(store: Store<WolfState>, abilities: Ability[
 /**
  * Find the next enabled and pending slot in the `focusedAbility` to be prompted
  */
-function findNextSlotToPrompt(getState: () => WolfState, abilities: Ability[]): SlotId | null {
+function findNextSlotToPrompt<T>(getState: () => WolfState, abilities: Ability<T>[]): SlotId | null {
   log('in findNextSlotToPrompt()..')
   const focusedAbility = getFocusedAbility(getState())
   log('focuedAbility to check:', focusedAbility)
@@ -249,7 +249,7 @@ function findNextSlotToPrompt(getState: () => WolfState, abilities: Ability[]): 
 /**
  * Check if there are any abilities with all enabled slots filled.
  */
-function getAbilitiesCompleted(getState: () => WolfState, abilities: Ability[]): string[] {
+function getAbilitiesCompleted<T>(getState: () => WolfState, abilities: Ability<T>[]): string[] {
   const filledSlotsResult = getfilledSlotsOnCurrentTurn(getState())
 
   if (filledSlotsResult.length === 0) {
@@ -266,9 +266,9 @@ function getAbilitiesCompleted(getState: () => WolfState, abilities: Ability[]):
  * Given an abilityName, check if the ability is completed based on pending slots.
  * Check if all enabled slots are filled.
  */
-function isAbilityCompletedByFilledSlotsOnCurrentTurn(
+function isAbilityCompletedByFilledSlotsOnCurrentTurn<T>(
   getState: () => WolfState,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   abilityName: string
 ): boolean {
   const state = getState()
@@ -298,9 +298,9 @@ function isAbilityCompletedByFilledSlotsOnCurrentTurn(
   return true
 }
 
-function getMissingSlotsOnSlotStatus(
+function getMissingSlotsOnSlotStatus<T>(
   getState: () => WolfState,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   focusedAbility: string
 ): SlotId[] {
   const ability = getTargetAbility(abilities, focusedAbility)
@@ -313,9 +313,9 @@ function getMissingSlotsOnSlotStatus(
     .map(_ => _.slotName)
   const abilitySlots = ability.slots
   return abilitySlots
-    .map(_ => _.name)
-    .filter(_ => namesOfSlotStatusOnAbility.indexOf(_) === -1)
-    .map(_ => ({
+    .map((_: Slot<T>) => _.name)
+    .filter((_: string) => namesOfSlotStatusOnAbility.indexOf(_) === -1)
+    .map((_: any) => ({
       abilityName: focusedAbility,
       slotName: _
     }))
@@ -324,7 +324,7 @@ function getMissingSlotsOnSlotStatus(
 /**
  * Find all unfilled slots in the target ability that are enabled. 
  */
-function getUnfilledSlots(getState: () => WolfState, abilities: Ability[], focusedAbility: string): Slot[] {
+function getUnfilledSlots<T>(getState: () => WolfState, abilities: Ability<T>[], focusedAbility: string): Slot<T>[] {
   const ability = getTargetAbility(abilities, focusedAbility)
   if (!ability) {
     // ability is undefined - exit
@@ -340,12 +340,12 @@ function getUnfilledSlots(getState: () => WolfState, abilities: Ability[], focus
   const allUnfilledSlotIds = missingSlotsOnSlotStatus.concat(unfilledEnabledSlotIdArray)
 
   return allUnfilledSlotIds
-    .map(({ slotName }) => abilitySlots.find(_ => _.name === slotName))
-    .filter(_ => _) as Slot[]
+    .map(({ slotName }) => abilitySlots.find((_: Slot<T>) => _.name === slotName))
+    .filter(_ => _) as Slot<T>[]
 }
 
 function getNextAbility<T>(
-  abilities: Ability[],
+  abilities: Ability<T>[],
   abilityName: string,
   convoState: T,
   state: WolfState

--- a/src/stages/evaluate.ts
+++ b/src/stages/evaluate.ts
@@ -1,9 +1,13 @@
 import { Store } from 'redux'
-import { WolfState, Ability, SlotId, Slot, PromptSlotReason, ConvoState,
-  NextAbilityResult, OutputMessageItem, OutputMessageType } from '../types'
-import { getAbilitiesCompleteOnCurrentTurn, getfilledSlotsOnCurrentTurn,
+import {
+  WolfState, Ability, SlotId, Slot, PromptSlotReason,
+  NextAbilityResult, OutputMessageItem, OutputMessageType
+} from '../types'
+import {
+  getAbilitiesCompleteOnCurrentTurn, getfilledSlotsOnCurrentTurn,
   getPromptedSlotStack, getFocusedAbility, getDefaultAbility, getSlotStatus,
-  getTargetAbility, getAbilityStatus, getUnfilledEnabledSlots } from '../selectors'
+  getTargetAbility, getAbilityStatus, getUnfilledEnabledSlots
+} from '../selectors'
 import { setFocusedAbility, addSlotToPromptedStack, abilityCompleted, addMessage } from '../actions'
 const logState = require('debug')('wolf:s3:enterState')
 const log = require('debug')('wolf:s3')
@@ -18,7 +22,7 @@ const log = require('debug')('wolf:s3')
  * @param store redux
  * @param abilities user defined abilities and slots
  */
-export default function evaluate(store: Store<WolfState>, abilities: Ability[], convoState: ConvoState): void {
+export default function evaluate<T>(store: Store<WolfState>, abilities: Ability[], convoState: T): void {
   const { dispatch, getState } = store
 
   const state = getState()
@@ -59,7 +63,7 @@ export default function evaluate(store: Store<WolfState>, abilities: Ability[], 
           log('nextAbility message is a string, add to output message queue')
           dispatch(addMessage({ message, type: OutputMessageType.nextAbilityMessage }))
         }
-        
+
         // ADD SLOT TO PROMPTED STACK
         log('add slot %s to the promptedStack', nextSlot.slotName)
         dispatch(addSlotToPromptedStack(nextSlot, PromptSlotReason.query))
@@ -69,7 +73,7 @@ export default function evaluate(store: Store<WolfState>, abilities: Ability[], 
     }
 
     // clear focused ability for now if next ability does not exist
-    log('set focused ability to null since no nextAbilityName exists')    
+    log('set focused ability to null since no nextAbilityName exists')
     dispatch(setFocusedAbility(null))
 
     log('exit stage')
@@ -136,7 +140,7 @@ export default function evaluate(store: Store<WolfState>, abilities: Ability[], 
       }
 
       // clear focused ability for now if next ability is completed (replace with above logic)
-      log('set focused ability to null since no nextAbilityName exists')   
+      log('set focused ability to null since no nextAbilityName exists')
       dispatch(setFocusedAbility(null))
 
       log('exit stage')
@@ -208,10 +212,10 @@ export default function evaluate(store: Store<WolfState>, abilities: Ability[], 
  * Find the next enabled and pending slot in the `focusedAbility` to be prompted
  */
 function findNextSlotToPrompt(getState: () => WolfState, abilities: Ability[]): SlotId | null {
-  log('in findNextSlotToPrompt()..')  
+  log('in findNextSlotToPrompt()..')
   const focusedAbility = getFocusedAbility(getState())
   log('focuedAbility to check:', focusedAbility)
-    
+
   if (!focusedAbility) {
     log('focused ability is empty.. return null')
     log('exiting findNextSlotToPrompt()')
@@ -253,7 +257,7 @@ function getAbilitiesCompleted(getState: () => WolfState, abilities: Ability[]):
   }
 
   const abilityList = filledSlotsResult.map((_) => _.abilityName)
-  const completedAbilityList = abilityList.filter((_) => 
+  const completedAbilityList = abilityList.filter((_) =>
     isAbilityCompletedByFilledSlotsOnCurrentTurn(getState, abilities, _))
   return completedAbilityList
 }
@@ -262,14 +266,14 @@ function getAbilitiesCompleted(getState: () => WolfState, abilities: Ability[]):
  * Given an abilityName, check if the ability is completed based on pending slots.
  * Check if all enabled slots are filled.
  */
-function isAbilityCompletedByFilledSlotsOnCurrentTurn (
+function isAbilityCompletedByFilledSlotsOnCurrentTurn(
   getState: () => WolfState,
   abilities: Ability[],
   abilityName: string
 ): boolean {
   const state = getState()
   const slotStatus = getSlotStatus(state)
-  
+
   const ability = abilities.find(_ => _.name === abilityName)
   if (!ability) {
     return false
@@ -336,14 +340,14 @@ function getUnfilledSlots(getState: () => WolfState, abilities: Ability[], focus
   const allUnfilledSlotIds = missingSlotsOnSlotStatus.concat(unfilledEnabledSlotIdArray)
 
   return allUnfilledSlotIds
-    .map(({slotName}) => abilitySlots.find(_ => _.name === slotName))
+    .map(({ slotName }) => abilitySlots.find(_ => _.name === slotName))
     .filter(_ => _) as Slot[]
 }
 
-function getNextAbility (
+function getNextAbility<T>(
   abilities: Ability[],
   abilityName: string,
-  convoState: ConvoState,
+  convoState: T,
   state: WolfState
 ): NextAbilityResult | null {
   const completedAbility = getTargetAbility(abilities, abilityName)
@@ -355,7 +359,7 @@ function getNextAbility (
   return null
 }
 
-function isAbilityCompleted (abilityName: string, getState: () => WolfState): boolean {
+function isAbilityCompleted(abilityName: string, getState: () => WolfState): boolean {
   const abilityStatus = getAbilityStatus(getState())
 
   return abilityStatus.some((ability) => ability.abilityName === abilityName && ability.isCompleted)

--- a/src/stages/execute.ts
+++ b/src/stages/execute.ts
@@ -44,7 +44,7 @@ const makeSubmittedDataFromSlotData = (slotData: SlotData[]) => {
 export default function execute<T>(
   store: Store<WolfState>,
   convoState: T,
-  abilities: Ability[]
+  abilities: Ability<T>[]
 ): ExecuteResult | void {
   const { dispatch, getState } = store
   logState(getState())
@@ -133,7 +133,7 @@ export default function execute<T>(
 function runAbilityOnComplete<T>(
   getState: () => WolfState,
   convoState: T,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   abilitiesToComplete: string[]
 ): {
   result: Promise<string | void> | string | void,
@@ -155,7 +155,7 @@ function runAbilityOnComplete<T>(
     const abilitySlotData = getSlotDataByAbilityName(getState(), ability.name)
     const submittedData = makeSubmittedDataFromSlotData(abilitySlotData)
 
-    const getStateFuncs: GetStateFunctions = {
+    const getStateFuncs: GetStateFunctions<T> = {
       getAbilityList: () => abilities
     }
 
@@ -183,7 +183,7 @@ function makeGetSlotDataFunctions({ getState }: Store<WolfState>, abilityName: s
 /**
  * Execute slot.query()
  */
-function runSlotQuery<T>(convoState: T, store: Store<WolfState>, slot: Slot, abilityName: string): Action[] {
+function runSlotQuery<T>(convoState: T, store: Store<WolfState>, slot: Slot<T>, abilityName: string): Action[] {
   const getSlotDataFunctions = makeGetSlotDataFunctions(store, abilityName)
   const queryString = slot.query(convoState, getSlotDataFunctions)
 

--- a/src/stages/execute.ts
+++ b/src/stages/execute.ts
@@ -1,10 +1,16 @@
-import { Store, Action, Dispatch } from 'redux'
-import { WolfState, Ability, Slot, ConvoState,
-  OutputMessageType, SlotId, SlotData, GetSlotDataFunctions, GetStateFunctions } from '../types'
-import { getAbilitiesCompleteOnCurrentTurn, getPromptedSlotStack,
-    getSlotBySlotId, getSlotDataByAbilityName } from '../selectors'
-import { addMessage as addMessageAction, setSlotPrompted, setAbilityStatus,
-  resetSlotStatusByAbilityName } from '../actions'
+import { Store, Action } from 'redux'
+import {
+  WolfState, Ability, Slot, OutputMessageType, SlotId,
+  SlotData, GetSlotDataFunctions, GetStateFunctions
+} from '../types'
+import {
+  getAbilitiesCompleteOnCurrentTurn, getPromptedSlotStack,
+  getSlotBySlotId, getSlotDataByAbilityName
+} from '../selectors'
+import {
+  addMessage as addMessageAction, setSlotPrompted, setAbilityStatus,
+  resetSlotStatusByAbilityName
+} from '../actions'
 import { findInSlotIdItemBySlotId } from '../helpers'
 const logState = require('debug')('wolf:s4:enterState')
 const log = require('debug')('wolf:s4')
@@ -35,16 +41,17 @@ const makeSubmittedDataFromSlotData = (slotData: SlotData[]) => {
  * @param convoState conversationState
  * @param abilities user defined abilities and slots
  */
-export default function execute(
+export default function execute<T>(
   store: Store<WolfState>,
-  convoState: ConvoState,
+  convoState: T,
   abilities: Ability[]
 ): ExecuteResult | void {
   const { dispatch, getState } = store
   logState(getState())
   const addMessage = (msg: OnCompletePromiseResult<string>) => dispatch(
     addMessageAction(
-      { message: msg.result,
+      {
+        message: msg.result,
         abilityName: msg.abilityName,
         type: OutputMessageType.abilityCompleteMessage
       }
@@ -57,21 +64,21 @@ export default function execute(
   const abilityCompleteResult = getAbilitiesCompleteOnCurrentTurn(getState())
   if (abilityCompleteResult.length > 0) {
     const valueOrPromiseArr = runAbilityOnComplete(getState, convoState, abilities, abilityCompleteResult)
-    const allPromises: Promise<(OnCompletePromiseResult<string|void>)>[] = valueOrPromiseArr.map((_) => {
+    const allPromises: Promise<(OnCompletePromiseResult<string | void>)>[] = valueOrPromiseArr.map((_) => {
       const { result: valueOrPromise, abilityName } = _
       if (typeof valueOrPromise === 'string') {
-        return Promise.resolve({result: valueOrPromise, abilityName})
+        return Promise.resolve({ result: valueOrPromise, abilityName })
       }
-      
+
       if (!valueOrPromise) {
         // void
-        return Promise.resolve({result: undefined, abilityName})
+        return Promise.resolve({ result: undefined, abilityName })
       }
-      
+
       // promise
       return valueOrPromise.then((result) => ({ result, abilityName }))
     })
-    
+
     abilityCompleteResult.forEach((abilityName: string) => {
       // set ability status to complete
       dispatch(setAbilityStatus(abilityName, true))
@@ -79,8 +86,8 @@ export default function execute(
       // reset all slot status to pending (isDone = false)
       dispatch(resetSlotStatusByAbilityName(abilityName))
     })
-    
-    onCompleteReturnResult = { 
+
+    onCompleteReturnResult = {
       runOnComplete: () => Promise.all(allPromises)
         .then(result => result.filter((_) => _.result)) as Promise<OnCompletePromiseResult<string>[]>,
       addMessage
@@ -110,7 +117,7 @@ export default function execute(
     }
     // SLOT NOT VALID.. continue
   }
-  
+
   if (onCompleteReturnResult) {
     return onCompleteReturnResult
   }
@@ -123,13 +130,13 @@ export default function execute(
 /**
  * Execute ability.onComplete()
  */
-function runAbilityOnComplete(
+function runAbilityOnComplete<T>(
   getState: () => WolfState,
-  convoState: ConvoState,
+  convoState: T,
   abilities: Ability[],
   abilitiesToComplete: string[]
 ): {
-  result: Promise<string|void> | string | void, 
+  result: Promise<string | void> | string | void,
   abilityName: string
 }[] {
 
@@ -164,19 +171,19 @@ function runAbilityOnComplete(
  * 
  * create an object that has the correct getters for slot information
  */
-function makeGetSlotDataFunctions({getState}: Store<WolfState>, abilityName: string): GetSlotDataFunctions {
+function makeGetSlotDataFunctions({ getState }: Store<WolfState>, abilityName: string): GetSlotDataFunctions {
   const wolfState = getState()
-  const {slotStatus, slotData} = wolfState
+  const { slotStatus, slotData } = wolfState
   return {
-    getSlotStatus: <SlotStatus>(slotName: string) => findInSlotIdItemBySlotId(slotStatus, {abilityName, slotName}),
-    getSlotValue: <SlotData>(slotName: string) => findInSlotIdItemBySlotId(slotData, {abilityName, slotName})
+    getSlotStatus: <SlotStatus>(slotName: string) => findInSlotIdItemBySlotId(slotStatus, { abilityName, slotName }),
+    getSlotValue: <SlotData>(slotName: string) => findInSlotIdItemBySlotId(slotData, { abilityName, slotName })
   }
 }
 
 /**
  * Execute slot.query()
  */
-function runSlotQuery(convoState: ConvoState, store: Store<WolfState>, slot: Slot, abilityName: string): Action[] {
+function runSlotQuery<T>(convoState: T, store: Store<WolfState>, slot: Slot, abilityName: string): Action[] {
   const getSlotDataFunctions = makeGetSlotDataFunctions(store, abilityName)
   const queryString = slot.query(convoState, getSlotDataFunctions)
 

--- a/src/stages/fillSlot.ts
+++ b/src/stages/fillSlot.ts
@@ -21,8 +21,8 @@ import { findSlotInAbilitiesBySlotId } from '../helpers'
 const logState = require('debug')('wolf:s2:enterState')
 const log = require('debug')('wolf:s2')
 
-interface PotentialSlotMatch {
-  slot: Slot,
+interface PotentialSlotMatch<T> {
+  slot: Slot<T>,
   abilityName: string,
   entity: string
 }
@@ -54,7 +54,7 @@ const hasSlotBeenFilledThisStage = (filledArray: SlotId[], slotId: SlotId): bool
 export default function fillSlot<T>(
   store: Store<WolfState>,
   convoState: T,
-  abilities: Ability[]
+  abilities: Ability<T>[]
 ): void {
   const { dispatch, getState } = store
   dispatch(startFillSlotStage()) // clear abilitiesCompleteOnCurrentTurn and filledSlotsOnCurrentTurn
@@ -183,7 +183,7 @@ export default function fillSlot<T>(
     if (ability) {
       log('%s ability Found in abilities.ts', ability.name)
       // find slot matches
-      const slotMatchesFocusedAbility: PotentialSlotMatch[] =
+      const slotMatchesFocusedAbility: PotentialSlotMatch<T>[] =
         getPotentialMatches(message.entities, ability)
 
       // process potential slot
@@ -249,7 +249,7 @@ export default function fillSlot<T>(
     // ABILITY EXISTS AND HAS SLOTS TO CHECK..
     if (ability) {
       log('ability match found and there are slots to check for matches')
-      const slotMatchesAllAbility: PotentialSlotMatch[] =
+      const slotMatchesAllAbility: PotentialSlotMatch<T>[] =
         getPotentialMatches(message.entities, ability)
 
       // process potential slot
@@ -312,7 +312,7 @@ export default function fillSlot<T>(
  */
 function fulfillSlot<T>(
   convoState: T,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   message: string,
   slotName: string,
   abilityName: string,
@@ -414,7 +414,7 @@ function runRetryCheck<T>(
   dispatch: Dispatch,
   getState: () => WolfState,
   convoState: T,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   matchNotValid: MatchNotValidData | null,
   potentialMatchFoundFlag: boolean,
   slotFillArr: SlotId[]
@@ -482,7 +482,7 @@ function runRetryCheck<T>(
 function runRetry<T>(
   convoState: T,
   getState: () => WolfState,
-  abilities: Ability[],
+  abilities: Ability<T>[],
   slotName: string,
   abilityName: string,
   submittedData: any
@@ -541,8 +541,8 @@ function createValidatorReasonMessage(
 function checkValidatorAndFill<T>(
   store: Store<WolfState>,
   convoState: T,
-  abilities: Ability[],
-  match: PotentialSlotMatch): SlotId | null {
+  abilities: Ability<T>[],
+  match: PotentialSlotMatch<T>): SlotId | null {
   log('in checkValidatorAndFill()..')
   const { dispatch, getState } = store
   const validatorResult = runSlotValidator(match.slot, match.entity, getMessageData(getState()))
@@ -572,7 +572,7 @@ function checkValidatorAndFill<T>(
 /**
  * Run slot validator.
  */
-function runSlotValidator(slot: Slot, submittedData: any, messageData: MessageData): ValidateResult {
+function runSlotValidator<T>(slot: Slot<T>, submittedData: any, messageData: MessageData): ValidateResult {
   if (!slot.validate) {
     return {
       isValid: true,
@@ -596,7 +596,7 @@ function isEntityPresent(value: MessageData) {
  * For each entity, check if the `entity.name` and `ability` given matches with any slot
  * in the `abilities`
  */
-function getPotentialMatches(entities: Entity[], targetAbility: Ability): PotentialSlotMatch[] {
+function getPotentialMatches<T>(entities: Entity[], targetAbility: Ability<T>): PotentialSlotMatch<T>[] {
   const slotMatches = targetAbility.slots.filter((slot) => entities.find((entity) => entity.name === slot.name))
 
   const matches = slotMatches.map((slot) => {
@@ -608,7 +608,7 @@ function getPotentialMatches(entities: Entity[], targetAbility: Ability): Potent
         entity: entityMatch.value
       }
     }
-  }).filter(_ => _) as PotentialSlotMatch[]
+  }).filter(_ => _) as PotentialSlotMatch<T>[]
 
   if (matches.length === 0) {
     return []

--- a/src/stages/outtake.ts
+++ b/src/stages/outtake.ts
@@ -1,5 +1,4 @@
 import { Store } from 'redux'
-import { Activity } from 'botbuilder'
 import { WolfState, OutputMessageItem, OutputMessageType } from '../types'
 import { getOutputMessageQueue } from '../selectors'
 import { clearMessageQueue } from '../actions'
@@ -8,7 +7,6 @@ const log = require('debug')('wolf:s5')
 export interface OuttakeResult {
   messageStringArray: string[],
   messageItemArray: OutputMessageItem[]
-  messageActivityArray: Partial<Activity>[]
 }
 
 /**
@@ -47,12 +45,7 @@ export default function outtake(store: Store<WolfState>): OuttakeResult {
   // clear messageQueue for next turn
   dispatch(clearMessageQueue())
 
-  const messageActivityArray: Partial<Activity>[] = messageStringArray.map((msg) => ({
-    type: 'message',
-    text: msg
-  }))
-
-  return { messageStringArray, messageItemArray, messageActivityArray } 
+  return { messageStringArray, messageItemArray }
 }
 
 /**

--- a/src/tests/pizza.test.ts
+++ b/src/tests/pizza.test.ts
@@ -3,32 +3,37 @@ import * as wolf from '..'
 import { getInitialWolfState, createStorage } from './testHelpers'
 import { Ability, WolfStateStorage } from '../types'
 import greetAbility from './testAbilities/greetAbility'
+import { UserConvoState } from './testAbilities/greetAbility'
 
-const abilities: Ability[] = [
+const abilities: Ability<UserConvoState>[] = [
   greetAbility
 ]
 
+const defualtStore: UserConvoState = {
+  name: null
+}
+
 const wolfStorage: WolfStateStorage = createStorage(getInitialWolfState())
-const convoStorage = createStorage({})
+const convoStorage = createStorage(defualtStore)
 
 describe('Greet', () => { // Feature (ability)
   test('Basic Greet Flow', async () => {
 
-  const outputResult = await wolf.run(
-    wolfStorage,
-    convoStorage,
-    () => ({message: 'hi', entities: [], intent: 'greet'}),
-    () => abilities,
-    'greet'
-  )
+    const outputResult = await wolf.run(
+      wolfStorage,
+      convoStorage,
+      () => ({ message: 'hi', entities: [], intent: 'greet' }),
+      () => abilities,
+      'greet'
+    )
 
     expect(outputResult.messageStringArray).toEqual(['What is your name?'])
-    expect(convoStorage.read()).toEqual({})
+    expect(convoStorage.read()).toEqual({ 'name': null })
 
     const outputResult2 = await wolf.run(
       wolfStorage,
       convoStorage,
-      () => ({message: 'Hao', entities: [], intent: null}),
+      () => ({ message: 'Hao', entities: [], intent: null }),
       () => abilities,
       'greet'
     )
@@ -39,7 +44,7 @@ describe('Greet', () => { // Feature (ability)
     const outputResult3 = await wolf.run(
       wolfStorage,
       convoStorage,
-      () => ({message: '3', entities: [], intent: null}),
+      () => ({ message: '3', entities: [], intent: null }),
       () => abilities,
       'greet'
     )
@@ -47,13 +52,13 @@ describe('Greet', () => { // Feature (ability)
     const outputResult4 = await wolf.run(
       wolfStorage,
       convoStorage,
-      () => ({message: '30', entities: [], intent: null}),
+      () => ({ message: '30', entities: [], intent: null }),
       () => abilities,
       'greet'
     )
 
     expect(outputResult4.messageStringArray).toEqual(['Hello Hao who is 30!'])
-    expect(convoStorage.read()).toEqual({name: 'Hao'})
+    expect(convoStorage.read()).toEqual({ name: 'Hao' })
 
   })
 })

--- a/src/tests/pizza.test.ts
+++ b/src/tests/pizza.test.ts
@@ -9,12 +9,12 @@ const abilities: Ability<UserConvoState>[] = [
   greetAbility
 ]
 
-const defualtStore: UserConvoState = {
+const defaultStore: UserConvoState = {
   name: null
 }
 
 const wolfStorage: WolfStateStorage = createStorage(getInitialWolfState())
-const convoStorage = createStorage(defualtStore)
+const convoStorage = createStorage(defaultStore)
 
 describe('Greet', () => { // Feature (ability)
   test('Basic Greet Flow', async () => {

--- a/src/tests/testAbilities/greetAbility.ts
+++ b/src/tests/testAbilities/greetAbility.ts
@@ -1,4 +1,8 @@
-import { Ability, ConvoState } from '../../types'
+import { Ability } from '../../types'
+
+export interface UserConvoState {
+  name: string | null
+}
 
 export default {
   name: 'greet',
@@ -7,25 +11,25 @@ export default {
       name: 'name',
       query: () => 'What is your name?',
       retry: () => 'try again',
-      validate: () => ({isValid: true, reason: null}),
-      onFill: () => {return}
+      validate: () => ({ isValid: true, reason: null }),
+      onFill: () => { return }
     },
     {
       name: 'age',
       query: () => 'What is your age?',
       retry: () => 'try again',
-      validate: (submittedValue) => {
-        const number = parseInt(submittedValue, 10);
-        if (number < 6) {
-          return {isValid: false, reason: 'too young'}
+      validate: (submittedValue: any) => {
+        const num = parseInt(submittedValue, 10);
+        if (num < 6) {
+          return { isValid: false, reason: 'too young' }
         }
-        return {isValid: true, reason: null}
+        return { isValid: true, reason: null }
       },
-      onFill: () => {return}
+      onFill: () => { return }
     }
   ],
-  onComplete: (convoState: ConvoState, submittedData) => {
+  onComplete: (convoState, submittedData: any) => {
     convoState.name = submittedData.name
     return `Hello ${submittedData.name} who is ${submittedData.age}!`
   }
-} as Ability
+} as Ability<UserConvoState>

--- a/src/types/ability.ts
+++ b/src/types/ability.ts
@@ -1,4 +1,4 @@
-import { ConvoState, MessageData, ValidateResult, WolfState } from './state'
+import { MessageData, ValidateResult, WolfState } from './state'
 import { SetSlotDataFunctions, GetSlotDataFunctions, GetStateFunctions, SlotConfirmationFunctions } from './function'
 
 /**
@@ -7,12 +7,12 @@ import { SetSlotDataFunctions, GetSlotDataFunctions, GetStateFunctions, SlotConf
  * 
  * See `example/` directory for ability examples for how to use.
  */
-export interface Ability {
+export interface Ability<T> {
   name: string,
-  slots: Slot[],
-  nextAbility?: (convoState: ConvoState, wolfState: WolfState) => NextAbilityResult,
-  onComplete: (convoState: ConvoState, submittedData: any, getStateFunctions: GetStateFunctions) => 
-    Promise<string|void> | string | void
+  slots: Slot<T>[],
+  nextAbility?: (convoState: T, wolfState: WolfState) => NextAbilityResult,
+  onComplete: (convoState: T, submittedData: any, getStateFunctions: GetStateFunctions<T>) =>
+    Promise<string | void> | string | void
 }
 
 /**
@@ -26,16 +26,16 @@ export interface NextAbilityResult {
 /**
  * Wolf primitive representing data points that should be collected.
  */
-export interface Slot {
+export interface Slot<T> {
   name: string,
   defaultIsEnabled?: boolean,
   order?: number,
-  query: (convoState: ConvoState, getSlotDataFunctions: GetSlotDataFunctions) => string,
+  query: (convoState: T, getSlotDataFunctions: GetSlotDataFunctions) => string,
   validate: (submittedValue: any, messageData: MessageData) => ValidateResult,
-  retry: (convoState: ConvoState, submittedData: any, turnCount: number) => string,
+  retry: (convoState: T, submittedData: any, turnCount: number) => string,
   onFill: (
     submittedValue: any,
-    convoState: ConvoState,
+    convoState: T,
     setOtherSlotFunctions: SetSlotDataFunctions,
     confirmationFunctions: SlotConfirmationFunctions
   ) => string | void

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -22,6 +22,6 @@ export interface SlotConfirmationFunctions {
   deny: () => void
 }
 
-export interface GetStateFunctions {
-  getAbilityList: () => Ability[]
+export interface GetStateFunctions<T> {
+  getAbilityList: () => Ability<T>[]
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,14 +1,6 @@
-import { Store, AnyAction } from 'redux';
-import { Promiseable } from './generic';
+import { Store, AnyAction } from 'redux'
 
-/**
- * Conversation state managed by Botbuilder
- */
-export interface ConvoState {
-  [key: string]: any
-}
-
-export type WolfStore = Store<WolfState, AnyAction>;
+export type WolfStore = Store<WolfState, AnyAction>
 
 /**
  * Wolf's state object that facilitates management of state sytem.

--- a/src/wolf/index.ts
+++ b/src/wolf/index.ts
@@ -124,7 +124,7 @@ export const run = async <T extends object>(
 
   // Save wolf state by invoking user defined save function
   const result = outtake(wolfStore)
-  
+
   await wolfStorage.save(wolfStore.getState())
 
   return result

--- a/src/wolf/index.ts
+++ b/src/wolf/index.ts
@@ -73,7 +73,7 @@ export const run = async <T extends object>(
   wolfStorage: WolfStateStorage,
   convoStorage: StorageLayer<T>,
   userMessageData: () => Promiseable<NlpResult>,
-  getAbilitiesFunc: () => Promiseable<Ability[]>,
+  getAbilitiesFunc: () => Promiseable<Ability<T>[]>,
   defaultAbility: string,
   storeCreator?: (wolfStateFromConvoState: { [key: string]: any } | null) => Store<WolfState>,
   getSlotDataFunc?: (setSlotFuncs: SetSlotDataFunctions) => Promiseable<IncomingSlotData[]>


### PR DESCRIPTION
All dependencies on Microsoft BotFramework have been removed.

The only exception is `botbuilder-wolf-rive` used for testing but this is only a naming convention that should be changed. @howlowck 

Moving away from a placeholder `ConvoState` with key value of `any`.. we are expecting a generic type `T` supplied by the user which will be used throughout Wolf. Please review this pattern, not sure if there are better alternatives. Generic `T` is heavily used throughout Wolf as a consequence.

closes #96 