### PR TITLE
Wolf API updated to accept multiple NlpResults

### DIFF
--- a/src/stages/intake.ts
+++ b/src/stages/intake.ts
@@ -22,31 +22,29 @@ export default function intake(
   logState(getState())
   dispatch(startIntakeStage())
 
-  // MessageData derived from user nlpResults
+  // MessageDataArr derived from user nlpResults
+  // Create the messageData array
+  const messageDataArr: MessageData[] = nlpResults.map(nlpResult => {
+    return {
+      rawText: nlpResult.message,
+      intent: nlpResult.intent,
+      entities: nlpResult.entities
+    }
+  })
 
-  let messageData: MessageData = { // default empty MessageData object
+  // Default empty MessageData object
+  // This default object is utilized if the incoming nlpResults array is empty
+  let messageData: MessageData = {
     rawText: '',
     intent: null,
     entities: []
   }
 
-  // if at least one nlpResult is present, capture first element data
-  if (nlpResults.length > 0) {
-    messageData = {
-      rawText: nlpResults[0].message,
-      intent: nlpResults[0].intent,
-      entities: nlpResults[0].entities
-    }
+  // If at least one nlpResult is present, capture first element data
+  // This is temp code. Future development will require the full messageDataArr to be saved onto WolfState
+  if (messageDataArr.length > 0) {
+    messageData = messageDataArr[0]
   }
-
-  // // MessageDataArr derived from user nlpResults
-  // const messageDataArr: MessageData[] = nlpResults.map(nlpResult => {
-  //   return {
-  //     rawText: nlpResult.message,
-  //     intent: nlpResult.intent,
-  //     entities: nlpResult.entities
-  //   }
-  // })
 
   // Write defaultAbility to state
   dispatch(setDefaultAbility(defaultAbility))

--- a/src/stages/intake.ts
+++ b/src/stages/intake.ts
@@ -43,6 +43,8 @@ export default function intake(
   // If at least one nlpResult is present, capture first element data
   // This is temp code. Future development will require the full messageDataArr to be saved onto WolfState
   if (messageDataArr.length > 0) {
+    log(`messageDataArr contains ${messageDataArr.length} elements.`)
+    log('Currently only utilizing the first element for messageData.')
     messageData = messageDataArr[0]
   }
 

--- a/src/stages/intake.ts
+++ b/src/stages/intake.ts
@@ -7,7 +7,7 @@ const log = require('debug')('wolf:s1')
 /**
  * Intake Stage (S1):
  * 
- * Takes in user generated NlpResult object and creates messageData object, stored to state.
+ * Takes in user generated NlpResult object and creates messageDataArr based on incoming NlpResults, stored to state.
  * 
  * @param nlpResult user generated NLP Object
  * 
@@ -15,18 +15,38 @@ const log = require('debug')('wolf:s1')
  */
 export default function intake(
   { dispatch, getState }: Store,
-  nlpResult: NlpResult,
+  nlpResults: NlpResult[],
   incomingSlotData: IncomingSlotData[],
   defaultAbility: string | null = null
 ): void {
   logState(getState())
   dispatch(startIntakeStage())
-  // MessageData derived from user nlpResult
-  const messageData: MessageData = {
-    rawText: nlpResult.message,
-    intent: nlpResult.intent,
-    entities: nlpResult.entities
+
+  // MessageData derived from user nlpResults
+
+  let messageData: MessageData = { // default empty MessageData object
+    rawText: '',
+    intent: null,
+    entities: []
   }
+
+  // if at least one nlpResult is present, capture first element data
+  if (nlpResults.length > 0) {
+    messageData = {
+      rawText: nlpResults[0].message,
+      intent: nlpResults[0].intent,
+      entities: nlpResults[0].entities
+    }
+  }
+
+  // // MessageDataArr derived from user nlpResults
+  // const messageDataArr: MessageData[] = nlpResults.map(nlpResult => {
+  //   return {
+  //     rawText: nlpResult.message,
+  //     intent: nlpResult.intent,
+  //     entities: nlpResult.entities
+  //   }
+  // })
 
   // Write defaultAbility to state
   dispatch(setDefaultAbility(defaultAbility))

--- a/src/tests/acceptance/asyncUserFunctions.test.ts
+++ b/src/tests/acceptance/asyncUserFunctions.test.ts
@@ -85,35 +85,35 @@ const optionalSlotPropertyTestCase: TestCase<UserConvoState, StorageLayerType<Us
   convoStorage,
   conversationTurns: [
     {
-      input: { message: 'hello', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hello', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please name an animal... if you want.'],
         state: { 'animalName': null, 'magicWordStrict': null, 'magicWordStrict2': null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please say \'wolf\'... not negotiable.'],
         state: { 'animalName': null, 'magicWordStrict': null, 'magicWordStrict2': null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please follow directions.'],
         state: { 'animalName': null, 'magicWordStrict': null, 'magicWordStrict2': null }
       }
     },
     {
-      input: { message: 'wolf', entities: [], intent: 'magicWord' },
+      input: [{ message: 'wolf', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please say \'wolf\' one more time.'],
         state: { 'animalName': null, 'magicWordStrict': null, 'magicWordStrict2': null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: [
           'Please follow directions.',
@@ -123,7 +123,7 @@ const optionalSlotPropertyTestCase: TestCase<UserConvoState, StorageLayerType<Us
       }
     },
     {
-      input: { message: 'wolf', entities: [], intent: 'magicWord' },
+      input: [{ message: 'wolf', entities: [], intent: 'magicWord' }],
       expected: {
         message: [
           'Submitted to async API! Thank you for saying wolf wolf!',

--- a/src/tests/acceptance/optionalAbilityProperties.test.ts
+++ b/src/tests/acceptance/optionalAbilityProperties.test.ts
@@ -86,33 +86,33 @@ const optionalAbilityPropertyTestCase: TestCase<UserConvoState, StorageLayerType
   convoStorage,
   conversationTurns: [
     {
-      input: {
+      input: [{
         message: 'i want to buy a Tesla',
         entities: [{ name: 'car', text: 'tesla', value: 'tesla' }],
         intent: 'buyCar'
-      },
+      }],
       expected: {
         message: ['What add on would you like?'],
         state: { car: 'tesla', addOns: [], financing: false }
       }
     },
     {
-      input: {
+      input: [{
         message: 'all wheel drive',
         entities: [],
         intent: null
-      },
+      }],
       expected: {
         message: ['Ok! lets go to the next step.', 'Would you need financing?'],
         state: { car: 'tesla', addOns: ['all wheel drive'], financing: false }
       }
     },
     {
-      input: {
+      input: [{
         message: 'yes',
         entities: [],
         intent: null
-      },
+      }],
       expected: {
         message: [],
         state: { car: 'tesla', addOns: ['all wheel drive'], financing: true }

--- a/src/tests/acceptance/optionalSlotProperties.test.ts
+++ b/src/tests/acceptance/optionalSlotProperties.test.ts
@@ -69,35 +69,35 @@ const optionalSlotPropertyTestCase: TestCase<UserConvoState, StorageLayerType<Us
   convoStorage,
   conversationTurns: [
     {
-      input: { message: 'hello', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hello', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please name an animal... if you want.'],
         state: { animalName: null, magicWordStrict: null, magicWordStrict2: null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please say \'wolf\'... not negotiable.'],
         state: { animalName: null, magicWordStrict: null, magicWordStrict2: null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please follow directions.'],
         state: { animalName: null, magicWordStrict: null, magicWordStrict2: null }
       }
     },
     {
-      input: { message: 'wolf', entities: [], intent: 'magicWord' },
+      input: [{ message: 'wolf', entities: [], intent: 'magicWord' }],
       expected: {
         message: ['Please say \'wolf\' one more time.'],
         state: { animalName: null, magicWordStrict: null, magicWordStrict2: null }
       }
     },
     {
-      input: { message: 'hippo', entities: [], intent: 'magicWord' },
+      input: [{ message: 'hippo', entities: [], intent: 'magicWord' }],
       expected: {
         message: [
           'Please follow directions.',
@@ -107,7 +107,7 @@ const optionalSlotPropertyTestCase: TestCase<UserConvoState, StorageLayerType<Us
       }
     },
     {
-      input: { message: 'wolf', entities: [], intent: 'magicWord' },
+      input: [{ message: 'wolf', entities: [], intent: 'magicWord' }],
       expected: {
         message: [
           'Thank you for saying wolf wolf!',

--- a/src/tests/acceptance/retainStateInEchoBot.test.ts
+++ b/src/tests/acceptance/retainStateInEchoBot.test.ts
@@ -58,55 +58,55 @@ const retainStateTestCase: TestCase<UserConvoState, StorageLayerType<UserConvoSt
   convoStorage,
   conversationTurns: [
     {
-      input: {
+      input: [{
         message: 'hello to the world as a phrase',
         entities: [],
         intent: null
-      },
+      }],
       expected: {
         message: ['You said "hello to the world as a phrase"'],
         state: { name: null, phrase: 'hello to the world as a phrase' }
       }
     },
     {
-      input: {
+      input: [{
         message: 'hi',
         entities: [],
         intent: 'greet'
-      },
+      }],
       expected: {
         message: ['what is your name?'],
         state: { name: null, phrase: 'hello to the world as a phrase' }
       }
     },
     {
-      input: {
+      input: [{
         message: 'dave',
         entities: [],
         intent: null,
-      },
+      }],
       expected: {
         message: ['hi dave!'],
         state: { name: 'dave', phrase: 'hello to the world as a phrase' }
       }
     },
     {
-      input: {
+      input: [{
         message: 'hi',
         entities: [{ name: 'firstName', text: 'bob', value: 'bob' }],
         intent: 'greet'
-      },
+      }],
       expected: {
         message: ['hi bob!'],
         state: { name: 'bob', phrase: 'hello to the world as a phrase' }
       }
     },
     {
-      input: {
+      input: [{
         message: 'hello there',
         entities: [],
         intent: null
-      },
+      }],
       expected: {
         message: ['bob said "hello there"'],
         state: { name: 'bob', phrase: 'hello there' }

--- a/src/tests/endToEnd/greet.test.ts
+++ b/src/tests/endToEnd/greet.test.ts
@@ -53,28 +53,28 @@ const greetTestCase: TestCase<UserConvoState, StorageLayerType<UserConvoState>> 
   convoStorage,
   conversationTurns: [
     {
-      input: { message: 'hi', entities: [], intent: 'greet' },
+      input: [{ message: 'hi', entities: [], intent: 'greet' }],
       expected: {
         message: ['What is your name?'],
         state: { name: null, age: null }
       }
     },
     {
-      input: { message: 'Hao', entities: [], intent: null },
+      input: [{ message: 'Hao', entities: [], intent: null }],
       expected: {
         message: ['What is your age?'],
         state: { name: null, age: null }
       }
     },
     {
-      input: { message: '3', entities: [], intent: null },
+      input: [{ message: '3', entities: [], intent: null }],
       expected: {
         message: ['too young', 'You must be older than 5.'],
         state: { name: null, age: null }
       }
     },
     {
-      input: { message: '30', entities: [], intent: null },
+      input: [{ message: '30', entities: [], intent: null }],
       expected: {
         message: ['Hello Hao who is 30!'],
         state: { name: 'Hao', age: '30' }

--- a/src/tests/helpers/index.ts
+++ b/src/tests/helpers/index.ts
@@ -2,7 +2,7 @@ import * as wolf from '../..'
 import { WolfState, AllSyncStorageLayer, Ability } from '../../types'
 
 export interface ConversationTurn<T> {
-  input: wolf.NlpResult,
+  input: wolf.NlpResult[],
   expected: { message: string[], state: T }
 }
 

--- a/src/wolf/index.ts
+++ b/src/wolf/index.ts
@@ -66,7 +66,7 @@ export const makeWolfStoreCreator = (
  * @param wolfStorage Wolf state storage layer. Wolf will handle saving wolf state
  * @param convoStorage User conversation state storage layer. Read/save will be made available
  * to user functions in slot and abilities
- * @param userMessageData Natural Language Processing result
+ * @param userMessageData An array of Natural Language Processing results
  * @param getAbilitiesFunc Abilities defined for the bot
  * @param defaultAbility Ability that will be used as the fallback if no ability is determined from the userMessageData
  * @param storeCreator Optional redux store creator, can be used with redux dev tools
@@ -76,14 +76,14 @@ export const makeWolfStoreCreator = (
 export const run = async <T extends AnyObject, G>(
   wolfStorage: WolfStateStorage,
   convoStorage: G,
-  userMessageData: () => Promiseable<NlpResult>,
+  userMessageData: () => Promiseable<NlpResult[]>,
   getAbilitiesFunc: () => Promiseable<Ability<T, G>[]>,
   defaultAbility: string,
   storeCreator?: (wolfStateFromConvoState: { [key: string]: any } | null) => Store<WolfState>,
   getSlotDataFunc?: (setSlotFuncs: SetSlotDataFunctions) => Promiseable<IncomingSlotData[]>
 ) => {
   // invoke user async functions
-  const [wolfState, nlpResult, abilities] = await Promise.all([
+  const [wolfState, nlpResultArr, abilities] = await Promise.all([
     wolfStorage.read(),
     userMessageData(),
     getAbilitiesFunc()
@@ -91,7 +91,7 @@ export const run = async <T extends AnyObject, G>(
 
   // If user provides storeCreator param, invoke the redux store creator with the persisted wolfState (if available)
   // By default, redux store creator is invoked with the available wolfState
-  // In either case, if wolfState is null, the storeCreator will instantiate a new defualt Wolf State
+  // In either case, if wolfState is null, the storeCreator will instantiate a new default Wolf State
   const wolfStore: WolfStore = storeCreator ? storeCreator(wolfState) : makeWolfStoreCreator()(wolfState)
 
   const incomingSlotData: IncomingSlotData[] = getSlotDataFunc ?
@@ -114,7 +114,7 @@ export const run = async <T extends AnyObject, G>(
         wolfStore.dispatch(addSlotToOnFillStack({ slotName, abilityName }, value))
       }
     }) : []
-  intake(wolfStore, nlpResult, incomingSlotData, defaultAbility)
+  intake(wolfStore, nlpResultArr, incomingSlotData, defaultAbility)
   await fillSlot(wolfStore, convoStorage, abilities)
   evaluate(wolfStore, abilities, convoStorage)
   const executeResult = await execute(wolfStore, convoStorage, abilities)


### PR DESCRIPTION
- Wolf runner updated signature to accept a `NlpResult[]`
- `TestCase` interfaces updated to accept array
- All tests updated and pass

ONLY Wolf runner API change. (see `intake.ts`)

What this PR is not:
Wolf stages are not able to process multiple `messageData` objects.
