### PR TITLE
Kslhacks/slot trace unit tests

### DIFF
--- a/src/helpers/trace.ts
+++ b/src/helpers/trace.ts
@@ -1,4 +1,5 @@
 import { Ability, SlotId, Trace } from '../types';
+import { getAbilityByName } from './ability';
 
 /**
  * Given a `slotId`, return the trace object associated with the `abilityName` and `slotName`
@@ -8,16 +9,12 @@ import { Ability, SlotId, Trace } from '../types';
  * @returns trace object
  */
 export const getTraceBySlotId = <T, G>(abilities: Ability<T, G>[], slotId: SlotId): Trace<G> => {
-  // TODO: Update when merging development branch to utilize `getAbilityByName`
-  const ability = abilities.find(_ => _.name === slotId.abilityName)
-  if (!ability) {
-    throw new Error(`Cannot find trace object. There is no ability called ${slotId.abilityName}.`)
-  }
-  
+  const ability = getAbilityByName(abilities, slotId.abilityName)
+
   const trace = ability.traces.find(_ => _.slotName === slotId.slotName)
   if (!trace) {
     throw new Error(`Cannot find trace object. There is no slot called ${slotId.slotName} in the ${slotId.abilityName} ability`)
   }
-  
+
   return trace
 }

--- a/src/tests/unit/helpers/slot.test.ts
+++ b/src/tests/unit/helpers/slot.test.ts
@@ -1,0 +1,51 @@
+import * as slotHelpers from '../../../../src/helpers/slot'
+import { Slot, AllSyncStorageLayer } from '../../../types';
+
+interface MockUserState {
+  firstName: string,
+  lastName: string,
+  age: number
+}
+
+describe('getSlotByName function', () => {
+  test('when slot array is empty', () => {
+    const slots: Slot<AllSyncStorageLayer<MockUserState>>[] = []
+    const slotName = 'slot1'
+
+    function runGetSlotByName() {
+      slotHelpers.getSlotByName(slots, slotName)
+    }
+    expect(runGetSlotByName).toThrowError(
+      `No slot exists given the slot name: ${slotName}`
+    )
+  })
+
+  test('when slot does not exist', () => {
+    const slots: Slot<AllSyncStorageLayer<MockUserState>>[] = [{
+      name: 'slot1',
+      query: () => 'what is slot1?'
+    }]
+    const slotName = 'slot2'
+
+    function runGetSlotByName() {
+      slotHelpers.getSlotByName(slots, slotName)
+    }
+    expect(runGetSlotByName).toThrowError(
+      `No slot exists given the slot name: ${slotName}`
+    )
+  })
+
+  test('when slot exists', () => {
+    const slots: Slot<AllSyncStorageLayer<MockUserState>>[] = [{
+      name: 'slot1',
+      query: () => 'what is slot1?'
+    }, {
+      name: 'slot2',
+      query: () => 'what is slot2?'
+    }]
+    const slotName = 'slot2'
+
+    const actual = slotHelpers.getSlotByName(slots, slotName)
+    expect(actual).toEqual(slots[1])
+  })
+})

--- a/src/tests/unit/helpers/slot.test.ts
+++ b/src/tests/unit/helpers/slot.test.ts
@@ -15,9 +15,7 @@ describe('getSlotByName function', () => {
     function runGetSlotByName() {
       slotHelpers.getSlotByName(slots, slotName)
     }
-    expect(runGetSlotByName).toThrowError(
-      `No slot exists given the slot name: ${slotName}`
-    )
+    expect(() => slotHelpers.getSlotByName(slots, slotName)).toThrow()
   })
 
   test('when slot does not exist', () => {
@@ -30,9 +28,7 @@ describe('getSlotByName function', () => {
     function runGetSlotByName() {
       slotHelpers.getSlotByName(slots, slotName)
     }
-    expect(runGetSlotByName).toThrowError(
-      `No slot exists given the slot name: ${slotName}`
-    )
+    expect(() => slotHelpers.getSlotByName(slots, slotName)).toThrow()
   })
 
   test('when slot exists', () => {

--- a/src/tests/unit/helpers/trace.test.ts
+++ b/src/tests/unit/helpers/trace.test.ts
@@ -28,8 +28,10 @@ describe('getTraceBySlotId function', () => {
       abilityName: 'ability4'
     }
 
-    // const actual = traceHelpers.getTraceBySlotId(abilities, slotId)
-    expect(traceHelpers.getTraceBySlotId(abilities, slotId)).toThrowError(
+    function runGetSlotByName() {
+      traceHelpers.getTraceBySlotId(abilities, slotId)
+    }
+    expect(runGetSlotByName).toThrowError(
       `Could not find ability with abilityName: ${slotId.abilityName} within abilities array`
     )
   })
@@ -54,8 +56,10 @@ describe('getTraceBySlotId function', () => {
       abilityName: 'ability3'
     }
 
-    const actual = traceHelpers.getTraceBySlotId(abilities, slotId)
-    expect(actual).toThrowError(
+    function runGetSlotByName() {
+      traceHelpers.getTraceBySlotId(abilities, slotId)
+    }
+    expect(runGetSlotByName).toThrowError(
       `Cannot find trace object. There is no slot called ${slotId.slotName} in the ${slotId.abilityName} ability`
     )
   })

--- a/src/tests/unit/helpers/trace.test.ts
+++ b/src/tests/unit/helpers/trace.test.ts
@@ -1,0 +1,86 @@
+import * as traceHelpers from '../../../../src/helpers/trace'
+import { Ability, AllSyncStorageLayer, SlotId } from '../../../types';
+
+interface MockUserState {
+  firstName: string,
+  lastName: SVGAnimatedString,
+  age: number
+}
+
+describe('getTraceBySlotId function', () => {
+  test('when ability does not exist', () => {
+    const abilities: Ability<MockUserState, AllSyncStorageLayer<MockUserState>>[] = [{
+      name: 'ability1',
+      traces: [],
+      onComplete: () => { return }
+    }, {
+      name: 'ability2',
+      traces: [],
+      onComplete: () => { return }
+    }, {
+      name: 'ability3',
+      traces: [],
+      onComplete: () => { return }
+    }]
+
+    const slotId: SlotId = {
+      slotName: 'slot1',
+      abilityName: 'ability4'
+    }
+
+    // const actual = traceHelpers.getTraceBySlotId(abilities, slotId)
+    expect(traceHelpers.getTraceBySlotId(abilities, slotId)).toThrowError(
+      `Could not find ability with abilityName: ${slotId.abilityName} within abilities array`
+    )
+  })
+
+  test('when slot does not exist on ability (trace does not exist)', () => {
+    const abilities: Ability<MockUserState, AllSyncStorageLayer<MockUserState>>[] = [{
+      name: 'ability1',
+      traces: [{ slotName: 'slot3' }],
+      onComplete: () => { return }
+    }, {
+      name: 'ability2',
+      traces: [{ slotName: 'slot3' }],
+      onComplete: () => { return }
+    }, {
+      name: 'ability3',
+      traces: [{ slotName: 'slot1' }, { slotName: 'slot2' }],
+      onComplete: () => { return }
+    }]
+
+    const slotId: SlotId = {
+      slotName: 'slot3',
+      abilityName: 'ability3'
+    }
+
+    const actual = traceHelpers.getTraceBySlotId(abilities, slotId)
+    expect(actual).toThrowError(
+      `Cannot find trace object. There is no slot called ${slotId.slotName} in the ${slotId.abilityName} ability`
+    )
+  })
+
+  test('when ability has slot', () => {
+    const abilities: Ability<MockUserState, AllSyncStorageLayer<MockUserState>>[] = [{
+      name: 'ability1',
+      traces: [{ slotName: 'slot3' }],
+      onComplete: () => { return }
+    }, {
+      name: 'ability2',
+      traces: [{ slotName: 'slot3' }],
+      onComplete: () => { return }
+    }, {
+      name: 'ability3',
+      traces: [{ slotName: 'slot1' }, { slotName: 'slot2' }, { slotName: 'slot3' }],
+      onComplete: () => { return }
+    }]
+
+    const slotId: SlotId = {
+      slotName: 'slot3',
+      abilityName: 'ability3'
+    }
+
+    const actual = traceHelpers.getTraceBySlotId(abilities, slotId)
+    expect(actual).toEqual(abilities[2].traces[2])
+  })
+})

--- a/src/tests/unit/helpers/trace.test.ts
+++ b/src/tests/unit/helpers/trace.test.ts
@@ -28,12 +28,7 @@ describe('getTraceBySlotId function', () => {
       abilityName: 'ability4'
     }
 
-    function runGetSlotByName() {
-      traceHelpers.getTraceBySlotId(abilities, slotId)
-    }
-    expect(runGetSlotByName).toThrowError(
-      `Could not find ability with abilityName: ${slotId.abilityName} within abilities array`
-    )
+    expect(() => traceHelpers.getTraceBySlotId(abilities, slotId)).toThrow()
   })
 
   test('when slot does not exist on ability (trace does not exist)', () => {
@@ -56,12 +51,7 @@ describe('getTraceBySlotId function', () => {
       abilityName: 'ability3'
     }
 
-    function runGetSlotByName() {
-      traceHelpers.getTraceBySlotId(abilities, slotId)
-    }
-    expect(runGetSlotByName).toThrowError(
-      `Cannot find trace object. There is no slot called ${slotId.slotName} in the ${slotId.abilityName} ability`
-    )
+    expect(() => traceHelpers.getTraceBySlotId(abilities, slotId)).toThrow()
   })
 
   test('when ability has slot', () => {


### PR DESCRIPTION
Adding unit tests for:
- `src/helpers/slot.ts`
- `src/helpers/trace.ts`

9/9 suites; 21/21 tests

Includes patterns for testing for exceptions thrown.