### PR TITLE
strongly typing defaultWolfState

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolf-core",
-  "version": "3.0.0-alpha.12",
+  "version": "3.0.0-alpha.13",
   "description": "",
   "main": "dist/index",
   "typings": "dist/index",

--- a/src/wolf/index.ts
+++ b/src/wolf/index.ts
@@ -15,7 +15,7 @@ import { fillSlot as fillSlotAction, enableSlot, disableSlot, setSlotDone, addSl
  * Returns the default Wolf State that should be initialized onto the conversation state
  * at the beginning of every conversation. This is meant for Wolf usage only.
  */
-export const getDefaultWolfState = () => {
+export const getDefaultWolfState = (): WolfState => {
   return {
     messageData: {
       rawText: '',
@@ -24,6 +24,7 @@ export const getDefaultWolfState = () => {
     },
     slotStatus: [],
     slotData: [],
+    slotRecords: [],
     abilityStatus: [],
     promptedSlotStack: [],
     focusedAbility: null,


### PR DESCRIPTION
Strongly typing `getDefaultWolfState` return type to `WolfState`. Updating to include `SlotRecord`